### PR TITLE
Fjernet rollefiltrering i PIP- og roles-endepunktene

### DIFF
--- a/Controllers/AuthorizationController.cs
+++ b/Controllers/AuthorizationController.cs
@@ -116,9 +116,6 @@ public class AuthorizationController : Controller
 
         var pipResponse = await _pipService.HandlePipRequest(pipRequest);
 
-        // We only want to return the roles assigned by the court (not including heir relation roles)
-        FilterCourtRoles(pipResponse);
-
         var roleAssignmentDtos =
             pipResponse.RoleAssignments.Select(pipRoleAssignment =>
                 new RoleAssignmentDto()
@@ -205,13 +202,6 @@ public class AuthorizationController : Controller
         };
 
         await _papService.Remove(papRequest);
-    }
-
-    private void FilterCourtRoles(PipResponse pipResponse)
-    {
-        pipResponse.RoleAssignments = pipResponse.RoleAssignments.Where(
-            x => x.RoleCode.StartsWith(Constants.CourtRoleCodePrefix)
-                 && !x.RoleCode.StartsWith(Constants.HeirRoleCodePrefix)).ToList();
     }
 
     private void FilterProxyRoles(PipResponse pipResponse)

--- a/Controllers/PipController.cs
+++ b/Controllers/PipController.cs
@@ -45,10 +45,6 @@ public class PipController : Controller
 
         var pipResponse = await _pipService.HandlePipRequest(pipRequest);
 
-        // The roles where there is an heir involved will have three parties (estate, heir and recipient) and
-        // is thus not appropiate for this endpoint. This includes the individual proxy role.
-        RemoveIndividualProxyRole(pipResponse);
-
         var pipRoleAssignmentsDto = pipResponse.RoleAssignments.Select(assignment =>
             new PipRoleAssignmentDto
             {
@@ -64,10 +60,5 @@ public class PipController : Controller
         };
 
         return pipResponseDto;
-    }
-
-    private void RemoveIndividualProxyRole(PipResponse pipResponse)
-    {
-        pipResponse.RoleAssignments = pipResponse.RoleAssignments.Where(x => !x.RoleCode.Equals(Constants.IndividualProxyRoleCode)).ToList();
     }
 }


### PR DESCRIPTION
* Fjernet filtrering av rollen skiftefullmakt:individuell i PIP response
* Roles-endepunktet returnerer nå alle roller, inkludert skiftefullmektige

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
