### PR TITLE
Role search now returns IsRestricted

### DIFF
--- a/src/oed-authz/Controllers/AuthorizationController.cs
+++ b/src/oed-authz/Controllers/AuthorizationController.cs
@@ -123,7 +123,8 @@ public class AuthorizationController : Controller
                     EstateSsn = pipRoleAssignment.EstateSsn,
                     RecipientSsn = pipRoleAssignment.RecipientSsn,
                     Role = pipRoleAssignment.RoleCode,
-                    Created = pipRoleAssignment.Created
+                    Created = pipRoleAssignment.Created,
+                    IsRestricted = pipRoleAssignment.IsRestricted
                 }).ToList();
 
         var rolesSearchResponseDto = new RolesSearchResponseDto()

--- a/src/oed-authz/Models/Dto/RoleAssignmentDto.cs
+++ b/src/oed-authz/Models/Dto/RoleAssignmentDto.cs
@@ -6,4 +6,5 @@ public class RoleAssignmentDto
     public string RecipientSsn { get; set; } = null!;
     public string Role { get; set; } = null!;
     public DateTimeOffset Created { get; set; }
+    public bool IsRestricted { get; set; }
 }

--- a/src/oed-authz/Models/PipRoleAssignment.cs
+++ b/src/oed-authz/Models/PipRoleAssignment.cs
@@ -12,4 +12,5 @@ public class PipRoleAssignment
     public string RecipientSsn { get; init; } = string.Empty;
 
     public DateTimeOffset Created { get; set; }
+    public bool IsRestricted { get; set; }
 }

--- a/src/oed-authz/Settings/Constants.cs
+++ b/src/oed-authz/Settings/Constants.cs
@@ -22,5 +22,7 @@ public static class Constants
     public const string CollectiveProxyRoleCode = "urn:altinn:digitaltdodsbo:skiftefullmakt:kollektiv";
     public const string ProbateRoleCode = "urn:domstolene:digitaltdodsbo:skifteattest";
     public const string FormuesfullmaktRoleCode = "urn:domstolene:digitaltdodsbo:formuesfullmakt";
+
+    public static IReadOnlyCollection<string> ProbateAndProxyRoles => [ProbateRoleCode, IndividualProxyRoleCode, CollectiveProxyRoleCode];
 }
 

--- a/test/oed-authz.UnitTests/Controllers/AuthorizationControllerTests.cs
+++ b/test/oed-authz.UnitTests/Controllers/AuthorizationControllerTests.cs
@@ -1,0 +1,71 @@
+﻿using oed_authz.Controllers;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using oed_authz.Interfaces;
+using oed_authz.Models;
+using oed_authz.Models.Dto;
+using oed_authz.Settings;
+
+namespace oed_authz.UnitTests.Controllers
+{
+    public class AuthorizationControllerTests
+    {
+        private readonly IPolicyInformationPointService _fakePipService = A.Fake<IPolicyInformationPointService>();
+        private readonly IProxyManagementService _fakeProxyManagementService = A.Fake<IProxyManagementService>();
+
+        public AuthorizationControllerTests()
+        {
+            A.CallTo(() => _fakePipService.HandlePipRequest(A<PipRequest>._))
+                .ReturnsLazily((call) =>
+                {
+                    var pipRequest = call.Arguments.Get<PipRequest>("pipRequest")!;
+                    return Task.FromResult(new PipResponse
+                    {
+                        EstateSsn = pipRequest.EstateSsn,
+                        RoleAssignments =
+                        [
+                            new PipRoleAssignment
+                            {
+                                EstateSsn = pipRequest.EstateSsn,
+                                Id = 100,
+                                RecipientSsn = "12345678901",
+                                RoleCode = Constants.ProbateRoleCode,
+                                Created = DateTimeOffset.UtcNow
+                            },
+                            new PipRoleAssignment
+                            {
+                                EstateSsn = pipRequest.EstateSsn,
+                                Id = 100,
+                                RecipientSsn = "12345678902",
+                                RoleCode = Constants.FormuesfullmaktRoleCode,
+                                Created = DateTimeOffset.UtcNow,
+                                IsRestricted = true
+                            }
+                        ]
+                    });
+                });
+        }
+
+        [Fact]
+        public async Task GetRoles_IsRestrictedAreMappepCorrectlyInResponse()
+        {   
+            // Arrange
+            var sut = new AuthorizationController(_fakePipService, _fakeProxyManagementService);
+
+            // Act
+            var mvcResult = await sut.GetRoles(new RolesSearchRequestDto { EstateSsn = "11111111111" });
+
+            // Assert
+            mvcResult.Result.Should().BeOfType<OkObjectResult>();
+            var okResult = mvcResult.Result as OkObjectResult;
+            okResult?.Value.Should().NotBeNull();
+            var response = okResult!.Value as RolesSearchResponseDto;
+            response.Should().NotBeNull();
+
+            response!.RoleAssignments.Should().HaveCount(2);
+            response.RoleAssignments.Should().ContainSingle(ra => ra.IsRestricted == false).Which.RecipientSsn.Should().Be("12345678901");
+            response.RoleAssignments.Should().ContainSingle(ra => ra.IsRestricted == true).Which.RecipientSsn.Should().Be("12345678902");
+        }
+    }
+}


### PR DESCRIPTION
Role search now returns an "isRestricted" field

## Description
In order for external parties to be able to authorize users we are now returning an "isRestricted" field in the role search response. This field will have the value "false" if the user has unrestricted acces to the estate and "true" if the user has restricted acces to the estate.

## Related Issue(s)
- #796

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
