### PR TITLE
Introduce eventcursors and transactional handling of events

### DIFF
--- a/src/oed-authz/Infrastructure/Database/Migrations/20250827131447_Add_table_eventcursor.Designer.cs
+++ b/src/oed-authz/Infrastructure/Database/Migrations/20250827131447_Add_table_eventcursor.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using oed_authz.Infrastructure.Database;
@@ -11,9 +12,11 @@ using oed_authz.Infrastructure.Database;
 namespace oed_authz.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(OedAuthzDbContext))]
-    partial class OedAuthzDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250827131447_Add_table_eventcursor")]
+    partial class Add_table_eventcursor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/oed-authz/Infrastructure/Database/Migrations/20250827131447_Add_table_eventcursor.cs
+++ b/src/oed-authz/Infrastructure/Database/Migrations/20250827131447_Add_table_eventcursor.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace oed_authz.Infrastructure.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_table_eventcursor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "eventcursor",
+                schema: "oedauthz",
+                columns: table => new
+                {
+                    estateSsn = table.Column<string>(type: "character(11)", fixedLength: true, maxLength: 11, nullable: false),
+                    eventType = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    lastTimestampProcessed = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("eventcursor_pkey", x => new { x.estateSsn, x.eventType });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "eventcursor",
+                schema: "oedauthz");
+        }
+    }
+}

--- a/src/oed-authz/Infrastructure/Database/Model/EventCursor.cs
+++ b/src/oed-authz/Infrastructure/Database/Model/EventCursor.cs
@@ -1,0 +1,8 @@
+﻿namespace oed_authz.Infrastructure.Database.Model;
+
+public class EventCursor
+{
+    public string EstateSsn { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public DateTimeOffset LastTimestampProcessed { get; set; } 
+}

--- a/src/oed-authz/Infrastructure/Database/Model/EventCursorConfiguration.cs
+++ b/src/oed-authz/Infrastructure/Database/Model/EventCursorConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace oed_authz.Infrastructure.Database.Model;
+
+public class EventCursorConfiguration : IEntityTypeConfiguration<EventCursor>
+{
+    public void Configure(EntityTypeBuilder<EventCursor> builder)
+    {
+        builder.ToTable("eventcursor", "oedauthz");
+
+        builder
+            .HasKey(e => new { e.EstateSsn, e.EventType })
+            .HasName("eventcursor_pkey");
+
+        builder.Property(e => e.EstateSsn)
+            .HasMaxLength(11)
+            .IsFixedLength()
+            .HasColumnName("estateSsn");
+
+        builder.Property(e => e.EventType)
+            .HasMaxLength(255)
+            .HasColumnName("eventType");
+
+        builder.Property(e => e.LastTimestampProcessed)
+            .HasColumnName("lastTimestampProcessed");
+    }
+}

--- a/src/oed-authz/Interfaces/IEventCursorRepository.cs
+++ b/src/oed-authz/Interfaces/IEventCursorRepository.cs
@@ -1,0 +1,15 @@
+﻿using oed_authz.Infrastructure.Database.Model;
+
+namespace oed_authz.Interfaces;
+
+public interface IEventCursorRepository
+{
+    /// <summary>
+    /// Will fetch cursor and lock the row for update
+    /// </summary>
+    /// <param name="estateSsn"></param>
+    /// <param name="eventType"></param>
+    /// <returns></returns>
+    public Task<EventCursor?> GetEventCursorForUpdate(string estateSsn, string eventType);
+    Task AddEventCursor(EventCursor cursor);
+}

--- a/src/oed-authz/Program.cs
+++ b/src/oed-authz/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddScoped<IProxyManagementService, ProxyManagementService>();
 builder.Services.AddScoped<IAuthorizationHandler, QueryParamRequirementHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, ScopeRequirementHandler>();
 builder.Services.AddScoped<IRoleAssignmentsRepository, RoleAssignmentsRepository>();
+builder.Services.AddScoped<IEventCursorRepository, EventCursorRepository>();
 
 builder.Services.AddOedAuthzDatabase(builder.Configuration);
 

--- a/src/oed-authz/Repositories/EventCursorRepository.cs
+++ b/src/oed-authz/Repositories/EventCursorRepository.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore;
+using oed_authz.Infrastructure.Database;
+using oed_authz.Infrastructure.Database.Model;
+using oed_authz.Interfaces;
+
+namespace oed_authz.Repositories;
+
+public class EventCursorRepository(OedAuthzDbContext dbContext) : IEventCursorRepository
+{
+    public async Task<EventCursor?> GetEventCursorForUpdate(string estateSsn, string eventType)
+    {
+        var eventCursor = await dbContext.Set<EventCursor>()
+            .FromSql($"""
+                      SELECT *
+                      FROM oedauthz.eventcursor 
+                      WHERE 
+                        "estateSsn" = {estateSsn}
+                        AND "eventType" = {eventType}
+                      FOR UPDATE LIMIT 1
+                      """)
+            .SingleOrDefaultAsync();
+
+        return eventCursor;
+    }
+
+    public async Task AddEventCursor(EventCursor cursor)
+    {
+        await dbContext.AddAsync(cursor);
+    }
+}

--- a/test/oed-authz.IntegrationTests/DatabaseFixture.cs
+++ b/test/oed-authz.IntegrationTests/DatabaseFixture.cs
@@ -1,4 +1,8 @@
-﻿using Testcontainers.PostgreSql;
+﻿using Microsoft.EntityFrameworkCore;
+using oed_authz.Infrastructure.Database;
+using oed_authz.Infrastructure.Database.Model;
+using oed_authz.Services;
+using Testcontainers.PostgreSql;
 
 namespace oed_authz.IntegrationTests;
 
@@ -9,12 +13,36 @@ public class DatabaseFixture : IAsyncLifetime
         new PostgreSqlBuilder()
             .Build();
 
+    public readonly string PreSeededEstateSsn = "12345678901";
+    public readonly string PreSeededEventType = Events.Oed.CaseStatusUpdateValidated;
+
     public string ConnectionString => _container.GetConnectionString();
 
     // Will return a unique fake Ssn for each call, allowing the unittests to be run in parallell with a saparate EstateSsn
     public string NextSsn => Interlocked.Increment(ref _ssn).ToString().PadLeft(11, '0');
 
     public string ContainerId => $"{_container.Id}";
-    public Task InitializeAsync() => _container.StartAsync();
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        await using var initDbContext = new OedAuthzDbContext(
+            new DbContextOptionsBuilder<OedAuthzDbContext>()
+                .UseNpgsql(ConnectionString)
+                .Options);
+
+        await initDbContext.Database.MigrateAsync();
+
+        await initDbContext.Set<EventCursor>().AddAsync(
+            new EventCursor
+            {
+                EstateSsn = PreSeededEstateSsn,
+                EventType = PreSeededEventType,
+                LastTimestampProcessed = new DateTimeOffset(2025, 8, 1, 18, 0, 0, 0, TimeSpan.Zero)
+            });
+
+        await initDbContext.SaveChangesAsync();
+    }
+
     public Task DisposeAsync() => _container.DisposeAsync().AsTask();
 }

--- a/test/oed-authz.IntegrationTests/Repositories/EventCursorRepositoryTests.cs
+++ b/test/oed-authz.IntegrationTests/Repositories/EventCursorRepositoryTests.cs
@@ -1,0 +1,86 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using oed_authz.Infrastructure.Database;
+using oed_authz.Infrastructure.Database.Model;
+using oed_authz.Repositories;
+using oed_authz.Services;
+
+namespace oed_authz.IntegrationTests.Repositories;
+
+public class EventCursorRepositoryTests(DatabaseFixture databaseFixture)
+    : IClassFixture<DatabaseFixture>, IAsyncLifetime
+{
+    private readonly OedAuthzDbContext _dbContext = new(
+        new DbContextOptionsBuilder<OedAuthzDbContext>()
+            .UseNpgsql(databaseFixture.ConnectionString)
+            .Options);
+
+    [Fact]
+    public async Task EventCursor_EnsureUniqueConstraint()
+    {
+        // Arrange
+
+        // Creating a cursor with same estateSsn and eventType as the one from seed data in InitializeAsync
+        var cursor = new EventCursor
+        {
+            EstateSsn = "12345678901",
+            EventType = Events.Oed.CaseStatusUpdateValidated,
+            LastTimestampProcessed = new DateTimeOffset(2025, 8, 1, 19, 0, 0, 0, TimeSpan.Zero)
+        };
+
+        // Act
+        await _dbContext.Set<EventCursor>().AddAsync(cursor);
+        
+        //await _dbContext.SaveChangesAsync();
+        var act = async () => await _dbContext.SaveChangesAsync();
+
+        // Assert
+        (await act.Should().ThrowAsync<DbUpdateException>())
+            .WithInnerException<PostgresException>()
+            .And.Message.Should().StartWith("23505");
+    }
+
+
+    [Fact]
+    public async Task GetEventCursorForUpdate_EnsureRowLock()
+    {
+        // Arrange
+        await using var anotherDbContext = new OedAuthzDbContext(
+            new DbContextOptionsBuilder<OedAuthzDbContext>()
+                .UseNpgsql(databaseFixture.ConnectionString)
+                .Options);
+
+        var anotherRepo = new EventCursorRepository(anotherDbContext);
+        
+        // Start another transaction and fetch the event cursor. This should cause a row-lock on the given cursor.
+        // As long as we do not release this lock by ending the transaction (commit/rollback),
+        // we should see a lock timeout when trying to fetch it again in the sut transaction below
+        await using var anotherTransaction = await anotherDbContext.Database.BeginTransactionAsync();
+        var anotherCursor = await anotherRepo.GetEventCursorForUpdate(
+            databaseFixture.PreSeededEstateSsn, 
+            databaseFixture.PreSeededEventType);
+
+        // Verify preconditions
+        anotherCursor.Should().NotBeNull();
+
+        var sut = new EventCursorRepository(_dbContext);
+
+        // Act
+        await using var sutTransaction = await _dbContext.Database.BeginTransactionAsync();
+        await _dbContext.Database.ExecuteSqlAsync($"SET LOCAL lock_timeout = '10ms'");
+
+        var act = async () => await sut.GetEventCursorForUpdate(
+            databaseFixture.PreSeededEstateSsn,
+            databaseFixture.PreSeededEventType);
+
+        // Assert
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithInnerException<PostgresException>()
+            .And.Message.Should().StartWith("55P03");
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
+++ b/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using oed_authz.Infrastructure.Database;
+using oed_authz.Infrastructure.Database.Model;
 using oed_authz.Models;
 using oed_authz.Models.Dto;
 using oed_authz.Repositories;
@@ -26,6 +27,8 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
                 .UseNpgsql(databaseFixture.ConnectionString)
                 .Options);
 
+        var eventCursorRepo = new EventCursorRepository(_dbContext);
+
         var roleAssignmentsRepository = new RoleAssignmentsRepository(
             _dbContext,
             A.Fake<ILogger<RoleAssignmentsRepository>>());
@@ -34,6 +37,8 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
             new ProxyManagementService(roleAssignmentsRepository, A.Fake<ILogger<ProxyManagementService>>());
 
         _sut = new AltinnEventHandlerService(
+            _dbContext,
+            eventCursorRepo,
             roleAssignmentsRepository,
             proxyManagementService,
             A.Fake<ILogger<AltinnEventHandlerService>>());
@@ -42,7 +47,7 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
     [Fact]
     public async Task HandleEvent_ShouldCreateRolesAccordingToCloudEvent_WhenEstateIsCreated()
     {
-     
+
         // Arrange
         var estateSsn = _databaseFixture.NextSsn;
 
@@ -67,8 +72,10 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
 
         var cloudEvent = new CloudEvent
         {
+            Time = DateTimeOffset.Now,
             Type = Events.Oed.CaseStatusUpdateValidated,
-            Subject = $"person/{estateSsn}",
+            //Subject = $"person/{estateSsn}",
+            Subject = estateSsn,
             Data = JsonSerializer.Serialize(eventRoleAssignments)
         };
 
@@ -81,8 +88,8 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
             .ToList();
 
         roleAssignments.Should().HaveCount(2);
-        roleAssignments.Should().ContainSingle(ra => 
-            ra.RecipientSsn == "99999999991" && 
+        roleAssignments.Should().ContainSingle(ra =>
+            ra.RecipientSsn == "99999999991" &&
             ra.RoleCode == Constants.FormuesfullmaktRoleCode);
         roleAssignments.Should().ContainSingle(ra =>
             ra.RecipientSsn == "99999999992" &&
@@ -139,6 +146,7 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
 
         var cloudEvent = new CloudEvent
         {
+            Time = DateTimeOffset.Now,
             Type = Events.Oed.CaseStatusUpdateValidated,
             Subject = $"person/{estateSsn}",
             Data = JsonSerializer.Serialize(eventRoleAssignments)
@@ -154,7 +162,377 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
 
         roleAssignments.Should().HaveCount(0);
     }
-    
-    public Task InitializeAsync() => _dbContext.Database.MigrateAsync();
+
+    [Fact]
+    public async Task HandleEvent_WithNoExistingEventCursor_ShouldInsertEventCursor_OnSuccess()
+    {
+        // Arrange
+        var estateSsn = _databaseFixture.NextSsn;
+        var daCaseId = Guid.NewGuid().ToString();
+        var timestamp = new DateTimeOffset(2025, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+        var roleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles =
+            [
+                new EventRoleAssignmentDto
+                {
+                    Nin = "99999999991",
+                    Role = Constants.FormuesfullmaktRoleCode
+                }
+            ]
+        };
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = timestamp,
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(roleAssignments),
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        var cursor = _dbContext.Set<EventCursor>()
+            .Single(c => c.EstateSsn == estateSsn);
+
+        cursor.Should().NotBeNull();
+        cursor.LastTimestampProcessed.Should().Be(timestamp);
+
+        var arrangedRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        arrangedRoleAssignments.Should().HaveCount(1);
+        arrangedRoleAssignments.Should().OnlyContain(ra => ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+    }
+
+    [Fact]
+    public async Task HandleEvent_WithExisitingEventCursor_ShouldUpdateEventCursor_OnSuccess()
+    {
+        // Arrange
+        var estateSsn = _databaseFixture.NextSsn;
+        var daCaseId = Guid.NewGuid().ToString();
+        var timestamp = new DateTimeOffset(2025, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+        var arrangeRoleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles = []
+        };
+
+        var arrangeCloudEvent = new CloudEvent
+        {
+            Time = timestamp.Subtract(TimeSpan.FromSeconds(1)),
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(arrangeRoleAssignments),
+        };
+
+        // First call to create cursor
+        await _sut.HandleEvent(arrangeCloudEvent);
+
+        // Verify preconditions
+        var arrangeCursor = _dbContext.Set<EventCursor>().Single(c => c.EstateSsn == estateSsn);
+        arrangeCursor.LastTimestampProcessed.Should().Be(timestamp.Subtract(TimeSpan.FromSeconds(1)));
+
+        // Act
+        var roleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles =
+            [
+                new EventRoleAssignmentDto
+                {
+                    Nin = "99999999991",
+                    Role = Constants.FormuesfullmaktRoleCode
+                }
+            ]
+        };
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = timestamp,
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(roleAssignments),
+        };
+
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        var cursor = _dbContext.Set<EventCursor>().Single(c => c.EstateSsn == estateSsn);
+        cursor.LastTimestampProcessed.Should().Be(timestamp);
+
+        var resultRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        resultRoleAssignments.Should().HaveCount(1);
+        resultRoleAssignments.Should().OnlyContain(ra => ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+    }
+
+    [Fact]
+    public async Task HandleEvent_WithExisitingEventCursor_ShouldNotUpdateEventCursor_OnFail()
+    {
+        // Arrange
+        var estateSsn = _databaseFixture.NextSsn;
+        var daCaseId = Guid.NewGuid().ToString();
+        var timestamp = new DateTimeOffset(2025, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+        var arrangeRoleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles = []
+        };
+
+        var arrangeCloudEvent = new CloudEvent
+        {
+            Time = timestamp.Subtract(TimeSpan.FromSeconds(1)),
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(arrangeRoleAssignments),
+        };
+
+        // First call to create cursor
+        await _sut.HandleEvent(arrangeCloudEvent);
+
+        // Verify preconditions
+        var arrangeCursor = _dbContext.Set<EventCursor>().Single(c => c.EstateSsn == estateSsn);
+        arrangeCursor.LastTimestampProcessed.Should().Be(timestamp.Subtract(TimeSpan.FromSeconds(1)));
+
+        // Act
+        var roleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles =
+            [
+                new EventRoleAssignmentDto
+                {
+                    Nin = "", // Should throws argument exception
+                    Role = Constants.FormuesfullmaktRoleCode
+                }
+            ]
+        };
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = timestamp,
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(roleAssignments),
+        };
+
+        var act = async () => await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+
+        var cursor = _dbContext.Set<EventCursor>().Single(c => c.EstateSsn == estateSsn);
+        cursor.LastTimestampProcessed.Should().Be(arrangeCursor.LastTimestampProcessed);
+
+        var resultRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        resultRoleAssignments.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public async Task HandleEvent_WithNoExistingEventCursor_ShouldNotInsertEventCursor_OnFail()
+    {
+        // Arrange
+        var estateSsn = _databaseFixture.NextSsn;
+        var daCaseId = Guid.NewGuid().ToString();
+        var timestamp = new DateTimeOffset(2025, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+        var roleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles =
+            [
+                new EventRoleAssignmentDto
+                {
+                    Nin = "", // Should throw ArgumentException
+                    Role = Constants.FormuesfullmaktRoleCode
+                }
+            ]
+        };
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = timestamp,
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(roleAssignments),
+        };
+
+        // Act
+        var act = async () => await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+
+        var cursor = _dbContext.Set<EventCursor>()
+            .SingleOrDefault(c => c.EstateSsn == estateSsn);
+
+        cursor.Should().BeNull();
+
+        var arrangedRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        arrangedRoleAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleEvent_OutOfOrderEvents_ShouldBeDiscarded()
+    {
+        // Arrange
+        var estateSsn = _databaseFixture.NextSsn;
+        var daCaseId = Guid.NewGuid().ToString();
+
+        var latestRoleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles =
+            [
+                new EventRoleAssignmentDto
+                {
+                    Nin = "99999999991",
+                    Role = Constants.FormuesfullmaktRoleCode
+                }
+            ]
+        };
+
+        var latestEvent = new CloudEvent
+        {
+            Time = new DateTimeOffset(2025, 8, 1, 18, 0, 0, TimeSpan.Zero), // 2025-08-01T18:00:00+00
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(latestRoleAssignments),
+        };
+
+        await _sut.HandleEvent(latestEvent);
+
+        // Verifying the preconditions
+        var arrangedRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        arrangedRoleAssignments.Should().HaveCount(1);
+        arrangedRoleAssignments.Should().OnlyContain(ra => ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+
+        // Act
+        var outOfOrderRoleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles = []
+        };
+
+        var outOfOrderEvent = new CloudEvent
+        {
+            Time = new DateTimeOffset(2025, 8, 1, 17, 0, 0, TimeSpan.Zero), // 2025-08-01T17:00:00+00
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(outOfOrderRoleAssignments),
+        };
+
+        await _sut.HandleEvent(outOfOrderEvent);
+
+        // Assert - The arranged roles should not have been changed => the out of order event withhout heirs have been discarded and not processed.
+        var resultRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        resultRoleAssignments.Should().HaveCount(1);
+        resultRoleAssignments.Should().OnlyContain(rra =>
+            rra.RoleCode == Constants.FormuesfullmaktRoleCode && // No changes in role codes
+            arrangedRoleAssignments.Any(ara =>
+                ara.Id == rra.Id)); // All the same ids as before. No delete with new inserts.
+    }
+
+    [Fact]
+    public async Task HandleEvent_EventsWithExactlySameTimestamp_LastEventShouldBeDiscarded()
+    {
+        // Arrange
+        var estateSsn = _databaseFixture.NextSsn;
+        var daCaseId = Guid.NewGuid().ToString();
+        var timestamp = new DateTimeOffset(2025, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+        var roleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles =
+            [
+                new EventRoleAssignmentDto
+                {
+                    Nin = "99999999991",
+                    Role = Constants.FormuesfullmaktRoleCode
+                }
+            ]
+        };
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = timestamp,
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(roleAssignments),
+        };
+
+        await _sut.HandleEvent(cloudEvent);
+
+        // Verifying the preconditions
+        var arrangedRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        arrangedRoleAssignments.Should().HaveCount(1);
+        arrangedRoleAssignments.Should().OnlyContain(ra => ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+
+        // Act
+        var anotherRoleAssignments = new EventRoleAssignmentDataDto
+        {
+            DaCaseId = daCaseId,
+            CaseStatus = CaseStatus.MOTTATT,
+            HeirRoles = []
+        };
+
+        var anotherEvent = new CloudEvent
+        {
+            Time = timestamp, // Same timestamp as the previus event
+            Type = Events.Oed.CaseStatusUpdateValidated,
+            Subject = $"person/{estateSsn}",
+            Data = JsonSerializer.Serialize(anotherRoleAssignments),
+        };
+
+        await _sut.HandleEvent(anotherEvent);
+
+        // Assert - The arranged roles should not have been changed => the out of order event withhout heirs have been discarded and not processed.
+        var resultRoleAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        resultRoleAssignments.Should().HaveCount(1);
+        resultRoleAssignments.Should().OnlyContain(rra =>
+            rra.RoleCode == Constants.FormuesfullmaktRoleCode && // No changes in role codes
+            arrangedRoleAssignments.Any(ara =>
+                ara.Id == rra.Id)); // All the same ids as before. No delete with new inserts.
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
     public Task DisposeAsync() => Task.CompletedTask;
 }

--- a/test/oed-authz.IntegrationTests/oed-authz.IntegrationTests.csproj
+++ b/test/oed-authz.IntegrationTests/oed-authz.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
Now using eventcursors persisted in the db to track the timestamp of the last processed event per estate and event type.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1337

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
