### PR TITLE
Remove access to estates 

### DIFF
--- a/src/oed-authz/Interfaces/IRoleAssignmentsRepository.cs
+++ b/src/oed-authz/Interfaces/IRoleAssignmentsRepository.cs
@@ -6,6 +6,7 @@ public interface IRoleAssignmentsRepository
 {
     public Task<List<RoleAssignment>> GetRoleAssignmentsForEstate(string estateSsn);
     public Task<List<RoleAssignment>> GetRoleAssignmentsForPerson(string estateSsn, string recipientSsn);
+    public Task<List<RoleAssignment>> GetAllRoleAssignmentsForPerson(string ssn);
     public Task AddRoleAssignment(RoleAssignment roleAssignment);
     public Task RemoveRoleAssignment(RoleAssignment roleAssignment);
 }

--- a/src/oed-authz/Repositories/RoleAssignmentsRepository.cs
+++ b/src/oed-authz/Repositories/RoleAssignmentsRepository.cs
@@ -38,6 +38,14 @@ namespace oed_authz.Repositories
                 .ToListAsync();
         }
 
+        public Task<List<RoleAssignment>> GetAllRoleAssignmentsForPerson(string ssn)
+        {
+            return _dbContext.RoleAssignments
+                .Where(ra => ra.HeirSsn == ssn || ra.RecipientSsn == ssn)
+                .AsNoTracking()
+                .ToListAsync();
+        }
+
         public Task RemoveRoleAssignment(RoleAssignment roleAssignment)
         {
             return _dbContext.RoleAssignments

--- a/src/oed-authz/Repositories/RoleAssignmentsRepository.cs
+++ b/src/oed-authz/Repositories/RoleAssignmentsRepository.cs
@@ -3,58 +3,63 @@ using oed_authz.Infrastructure.Database;
 using oed_authz.Interfaces;
 using oed_authz.Models;
 
-namespace oed_authz.Repositories
+namespace oed_authz.Repositories;
+
+public class RoleAssignmentsRepository : IRoleAssignmentsRepository
 {
-    public class RoleAssignmentsRepository : IRoleAssignmentsRepository
+    private readonly OedAuthzDbContext _dbContext;
+
+    public RoleAssignmentsRepository(OedAuthzDbContext dbContext)
     {
-        private readonly OedAuthzDbContext _dbContext;
+        _dbContext = dbContext;
+    }
 
-        public RoleAssignmentsRepository(OedAuthzDbContext dbContext)
-        {
-            _dbContext = dbContext;
-        }
+    public async Task AddRoleAssignment(RoleAssignment roleAssignment)
+    {
+        await _dbContext.RoleAssignments.AddAsync(roleAssignment);
+        await _dbContext.SaveChangesAsync();
+    }
 
-        public async Task AddRoleAssignment(RoleAssignment roleAssignment)
-        {
-            await _dbContext.RoleAssignments.AddAsync(roleAssignment);
-            await _dbContext.SaveChangesAsync();
-        }
+    public Task<List<RoleAssignment>> GetRoleAssignmentsForEstate(string estateSsn)
+    {
+        return _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .AsNoTracking()
+            .ToListAsync();
+    }
 
-        public Task<List<RoleAssignment>> GetRoleAssignmentsForEstate(string estateSsn)
-        {
-            return _dbContext.RoleAssignments
-                .Where(ra => ra.EstateSsn == estateSsn)
-                .AsNoTracking()
-                .ToListAsync();
-        }
+    public Task<List<RoleAssignment>> GetRoleAssignmentsForPerson(string estateSsn, string recipientSsn)
+    {
+        if (string.IsNullOrWhiteSpace(recipientSsn))
+            return Task.FromResult(new List<RoleAssignment>());
 
-        public Task<List<RoleAssignment>> GetRoleAssignmentsForPerson(string estateSsn, string recipientSsn)
-        {
-            return _dbContext.RoleAssignments
-                .Where(ra =>                     
-                    ra.EstateSsn == estateSsn
-                    && ra.RecipientSsn == recipientSsn)
-                .AsNoTracking()
-                .ToListAsync();
-        }
+        return _dbContext.RoleAssignments
+            .Where(ra =>
+                ra.EstateSsn == estateSsn
+                && ra.RecipientSsn == recipientSsn)
+            .AsNoTracking()
+            .ToListAsync();
+    }
 
-        public Task<List<RoleAssignment>> GetAllRoleAssignmentsForPerson(string ssn)
-        {
-            return _dbContext.RoleAssignments
-                .Where(ra => ra.HeirSsn == ssn || ra.RecipientSsn == ssn)
-                .AsNoTracking()
-                .ToListAsync();
-        }
+    public Task<List<RoleAssignment>> GetAllRoleAssignmentsForPerson(string ssn)
+    {
+        if (string.IsNullOrWhiteSpace(ssn))
+            return Task.FromResult(new List<RoleAssignment>());
 
-        public Task RemoveRoleAssignment(RoleAssignment roleAssignment)
-        {
-            return _dbContext.RoleAssignments
-                .Where(ra =>
-                    ra.EstateSsn == roleAssignment.EstateSsn
-                    && ra.RecipientSsn == roleAssignment.RecipientSsn
-                    && ra.RoleCode == roleAssignment.RoleCode
-                    && ra.HeirSsn == roleAssignment.HeirSsn)
-                .ExecuteDeleteAsync();
-        }
+        return _dbContext.RoleAssignments
+            .Where(ra => ra.HeirSsn == ssn || ra.RecipientSsn == ssn)
+            .AsNoTracking()
+            .ToListAsync();
+    }
+
+    public Task RemoveRoleAssignment(RoleAssignment roleAssignment)
+    {
+        return _dbContext.RoleAssignments
+            .Where(ra =>
+                ra.EstateSsn == roleAssignment.EstateSsn
+                && ra.RecipientSsn == roleAssignment.RecipientSsn
+                && ra.RoleCode == roleAssignment.RoleCode
+                && ra.HeirSsn == roleAssignment.HeirSsn)
+            .ExecuteDeleteAsync();
     }
 }

--- a/src/oed-authz/Services/EventHandlerService.cs
+++ b/src/oed-authz/Services/EventHandlerService.cs
@@ -74,7 +74,7 @@ public class AltinnEventHandlerService(
                     ProxyRoleAssignment = new()
                     {
                         Created = ra.Created,
-                        HeirSsn = ra.HeirSsn,
+                        HeirSsn = ra.HeirSsn!,
                         RecipientSsn = ra.RecipientSsn,
                         RoleCode = ra.RoleCode
                     }

--- a/src/oed-authz/Services/EventHandlerService.cs
+++ b/src/oed-authz/Services/EventHandlerService.cs
@@ -24,7 +24,7 @@ public class AltinnEventHandlerService(
         {
             EventType.CaseStatusUpdateValidated or EventType.CaseStatusManuallySynced =>
                 HandleEstateInstanceCreatedOrUpdated(cloudEvent),
-            EventType.FregProtectedAddressUpdate => 
+            EventType.FregProtectedAddressUpdate =>
                 HandleProtectedAddressUpdate(cloudEvent),
             Events.Platform.ValidateSubscription => Task.CompletedTask,
             _ => throw new ArgumentException("Unknown event type")
@@ -39,20 +39,50 @@ public class AltinnEventHandlerService(
 
         var eventData = JsonSerializer.Deserialize<FregProtectedAddressUpdateEvent>(fregEvent.Data.ToString()!);
 
+        if (eventData is null)
+        {
+            return;
+        }
+
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
-        var roleAssignmentsForPerson = await oedRoleRepositoryService.GetAllRoleAssignmentsForPerson(eventData!.Nin);
-     
-        var estatesPersonIsPartOf = roleAssignmentsForPerson
-            .Select(x => x.EstateSsn)
-            .Distinct();
-        
-        foreach (var estateSsn in estatesPersonIsPartOf)
-        {
-            logger.LogInformation("Removing all role assignments for estate {EstateSsn} due to protected address update for person with Nin {Nin}",
-                estateSsn, SsnUtils.TruncateSsn(eventData.Nin));
+        var roleAssignmentsForPerson = await oedRoleRepositoryService.GetAllRoleAssignmentsForPerson(eventData.Nin);
 
-            await RemoveAllRoleAssignmentsForEstate(estateSsn, fregEvent.Id);
+        foreach (RoleAssignment ra in roleAssignmentsForPerson)
+        {
+            // Affected nin is the recipient of an individual proxy: revoke only that delegation.
+            // Removing it cascades any collective proxy the person held because of it.
+            if (ra.RecipientSsn == eventData.Nin && ra.HeirSsn is not null)
+            {
+                logger.LogInformation("Removing individual proxy role for {Nin} in {EstateSsn}",
+                    SsnUtils.TruncateSsn(eventData.Nin), ra.EstateSsn);
+
+                await proxyManagementService.Remove(new()
+                {
+                    EstateSsn = ra.EstateSsn,
+                    ProxyRoleAssignment = new()
+                    {
+                        Created = ra.Created,
+                        HeirSsn = ra.HeirSsn,
+                        RecipientSsn = ra.RecipientSsn,
+                        RoleCode = ra.RoleCode
+                    }
+                });
+                continue;
+            }
+
+            // Affected nin is the recipient of the auto-managed collective proxy. A collective
+            // proxy always derives from one or more individual proxies, which are handled above -
+            // their removal cascades (via UpdateProxyRoleAssigments) into revoking this collective
+            // proxy. We only skip here so the stale snapshot row does not fall through to the
+            // estate wipe below; the person is a proxy holder, not an heir.
+            if (ra.RecipientSsn == eventData.Nin && ra.RoleCode == Constants.CollectiveProxyRoleCode)
+            {
+                continue;
+            }
+
+            logger.LogInformation("Removing all role assignments for estate {EstateSsn}", ra.EstateSsn);
+            await RemoveAllRoleAssignmentsForEstate(ra.EstateSsn, fregEvent.Id);
         }
 
         await transaction.CommitAsync();
@@ -63,13 +93,13 @@ public class AltinnEventHandlerService(
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
         var eventCursor = await GetOrCreateEventCursorForUpdate(daEvent);
-        
+
         // Discard event if out of order
         if (EventIsOutOfOrder(eventCursor, daEvent))
         {
             logger.LogInformation(
                 "Discarding event {Id} of type {EventType} for estate {Estate} - event is out of order",
-                daEvent.Id, 
+                daEvent.Id,
                 daEvent.Type,
                 daEvent.Subject);
 
@@ -83,7 +113,7 @@ public class AltinnEventHandlerService(
 
         var estateSsn = SsnUtils.GetEstateSsnFromCloudEvent(daEvent);
 
-        if (eventData.IsFeilfort() || 
+        if (eventData.IsFeilfort() ||
             eventData.HasIncompleteRoleInformation())
         {
             await RemoveAllRoleAssignmentsForEstate(estateSsn, daEvent.Id);
@@ -102,7 +132,7 @@ public class AltinnEventHandlerService(
 
     private async Task UpdateCourtAssignedRoleAssignments(
         string estateSsn,
-        EstateCaseUpdatedEvent eventData, 
+        EstateCaseUpdatedEvent eventData,
         string eventId,
         DateTimeOffset eventTime)
     {
@@ -113,7 +143,7 @@ public class AltinnEventHandlerService(
 
         // Find assignments in updated list but not in current list to add
         var assignmentsToAdd = new List<RoleAssignment>();
-        
+
         // Only persons with Nin and a valid role code can be given access
         var eventRoleAssignments =
             eventData.HeirRolesV2
@@ -131,8 +161,8 @@ public class AltinnEventHandlerService(
             }
 
             if (!currentCourtAssignedRoleAssignments
-                .Exists(x => 
-                    x.RecipientSsn == updatedRoleAssignment.Nin && 
+                .Exists(x =>
+                    x.RecipientSsn == updatedRoleAssignment.Nin &&
                     x.RoleCode == updatedRoleAssignment.Role))
             {
                 assignmentsToAdd.Add(new RoleAssignment
@@ -150,7 +180,7 @@ public class AltinnEventHandlerService(
         foreach (var currentRoleAssignment in currentCourtAssignedRoleAssignments)
         {
             if (!eventRoleAssignments.Any(x =>
-                    x.Nin == currentRoleAssignment.RecipientSsn && 
+                    x.Nin == currentRoleAssignment.RecipientSsn &&
                     x.Role == currentRoleAssignment.RoleCode))
             {
                 assignmentsToRemove.Add(new RoleAssignment

--- a/src/oed-authz/Services/EventHandlerService.cs
+++ b/src/oed-authz/Services/EventHandlerService.cs
@@ -33,10 +33,29 @@ public class AltinnEventHandlerService(
 
     private async Task HandleProtectedAddressUpdate(CloudEvent fregEvent)
     {
-        logger.LogInformation("Placeholder for handling protected address update event {Id} of type {EventType} for subject {Subject}",
-            fregEvent.Id, 
-            fregEvent.Type, 
-            fregEvent.Subject[..Math.Min(fregEvent.Subject.Length, 6)]);
+        ThrowIfEmptyData(fregEvent);
+
+        logger.LogInformation("Handling protected address update event {Id} from freg", fregEvent.Id);
+
+        var eventData = JsonSerializer.Deserialize<FregProtectedAddressUpdateEvent>(fregEvent.Data.ToString()!);
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+        var roleAssignmentsForPerson = await oedRoleRepositoryService.GetAllRoleAssignmentsForPerson(eventData!.Nin);
+     
+        var estatesPersonIsPartOf = roleAssignmentsForPerson
+            .Select(x => x.EstateSsn)
+            .Distinct();
+        
+        foreach (var estateSsn in estatesPersonIsPartOf)
+        {
+            logger.LogInformation("Removing all role assignments for estate {EstateSsn} due to protected address update for person with Nin {Nin}",
+                estateSsn, SsnUtils.TruncateSsn(eventData.Nin));
+
+            await RemoveAllRoleAssignmentsForEstate(estateSsn, fregEvent.Id);
+        }
+
+        await transaction.CommitAsync();
     }
 
     private async Task HandleEstateInstanceCreatedOrUpdated(CloudEvent daEvent)
@@ -57,11 +76,7 @@ public class AltinnEventHandlerService(
             return;
         }
 
-        if (daEvent.Data == null)
-        {
-            logger.LogError("Empty data in event: {CloudEvent}", JsonSerializer.Serialize(daEvent));
-            throw new ArgumentNullException(nameof(daEvent.Data));
-        }
+        ThrowIfEmptyData(daEvent);
 
         var eventData = JsonSerializer.Deserialize<EstateCaseUpdatedEvent>(daEvent.Data.ToString()!)!;
         logger.LogInformation("Handling event {Id} for DA caseId: {DaCaseId}", daEvent.Id, eventData.CaseId);
@@ -172,6 +187,15 @@ public class AltinnEventHandlerService(
         foreach (var roleAssignment in assignmentsToRemove)
         {
             await oedRoleRepositoryService.RemoveRoleAssignment(roleAssignment);
+        }
+    }
+
+    private void ThrowIfEmptyData(CloudEvent cloudEvent)
+    {
+        if (cloudEvent.Data == null)
+        {
+            logger.LogError("Empty data in event {Id} of type {EventType}", cloudEvent.Id, cloudEvent.Type);
+            throw new ArgumentNullException(nameof(cloudEvent), "CloudEvent data is null");
         }
     }
 

--- a/src/oed-authz/Services/EventHandlerService.cs
+++ b/src/oed-authz/Services/EventHandlerService.cs
@@ -46,16 +46,27 @@ public class AltinnEventHandlerService(
 
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
-        var roleAssignmentsForPerson = await oedRoleRepositoryService.GetAllRoleAssignmentsForPerson(eventData.Nin);
+        var nin = eventData.Nin;
+        var roleAssignmentsForPerson = await oedRoleRepositoryService.GetAllRoleAssignmentsForPerson(nin);
 
-        foreach (RoleAssignment ra in roleAssignmentsForPerson)
+        // Handle each estate the person is part of
+        foreach (var estateGroup in roleAssignmentsForPerson.GroupBy(ra => ra.EstateSsn))
         {
-            // Affected nin is the recipient of an individual proxy: revoke only that delegation.
-            // Removing it cascades any collective proxy the person held because of it.
-            if (ra.RecipientSsn == eventData.Nin && ra.HeirSsn is not null)
+            var estateSsn = estateGroup.Key;
+            var rows = estateGroup.ToList();
+
+            // Heir (holds a court role, or delegated a proxy) -> wipe the whole estate.
+            if (IsHeir(nin, rows))
+            {
+                await RemoveAllRoleAssignmentsForEstate(estateSsn, fregEvent.Id);
+                continue;
+            }
+
+            // Proxy recipient only -> revoke their individual proxy delegation(s).
+            foreach (var ra in rows.Where(r => r.RecipientSsn == nin && r.HeirSsn is not null))
             {
                 logger.LogInformation("Removing individual proxy role for {Nin} in {EstateSsn}",
-                    SsnUtils.TruncateSsn(eventData.Nin), ra.EstateSsn);
+                    SsnUtils.TruncateSsn(nin), estateSsn);
 
                 await proxyManagementService.Remove(new()
                 {
@@ -68,24 +79,17 @@ public class AltinnEventHandlerService(
                         RoleCode = ra.RoleCode
                     }
                 });
-                continue;
             }
-
-            // Affected nin is the recipient of the auto-managed collective proxy. A collective
-            // proxy always derives from one or more individual proxies, which are handled above -
-            // their removal cascades (via UpdateProxyRoleAssigments) into revoking this collective
-            // proxy. We only skip here so the stale snapshot row does not fall through to the
-            // estate wipe below; the person is a proxy holder, not an heir.
-            if (ra.RecipientSsn == eventData.Nin && ra.RoleCode == Constants.CollectiveProxyRoleCode)
-            {
-                continue;
-            }
-
-            logger.LogInformation("Removing all role assignments for estate {EstateSsn}", ra.EstateSsn);
-            await RemoveAllRoleAssignmentsForEstate(ra.EstateSsn, fregEvent.Id);
         }
 
         await transaction.CommitAsync();
+    }
+
+    private static bool IsHeir(string nin, IEnumerable<RoleAssignment> rows)
+    {
+        return rows.Any(ra => 
+            (ra.RecipientSsn == nin && ra.HeirSsn is null && ra.RoleCode != Constants.CollectiveProxyRoleCode)
+            || ra.HeirSsn == nin);
     }
 
     private async Task HandleEstateInstanceCreatedOrUpdated(CloudEvent daEvent)

--- a/src/oed-authz/Utils/SsnUtils.cs
+++ b/src/oed-authz/Utils/SsnUtils.cs
@@ -1,19 +1,19 @@
 ﻿using oed_authz.Models;
 
 namespace oed_authz.Utils;
+
 public static class SsnUtils
 {
     public static bool IsValidSsn(string estateSsnOnly)
     {
-        return estateSsnOnly.Length == 11 && estateSsnOnly.All(t => t is >= '0' and <= '9');
+        return estateSsnOnly is not null
+            && estateSsnOnly.Length == 11 
+            && estateSsnOnly.All(Char.IsAsciiDigit);
     }
 
     public static string GetEstateSsnFromCloudEvent(CloudEvent daEvent)
     {
-        if (daEvent.Subject == null)
-        {
-            throw new ArgumentNullException(nameof(daEvent), "Missing daEvent.Subject");
-        }
+        ArgumentException.ThrowIfNullOrEmpty(daEvent.Subject);
 
         if (IsValidSsn(daEvent.Subject))
         {
@@ -35,7 +35,7 @@ public static class SsnUtils
         {
             return ssn;
         }
-     
+
         return ssn[..6];
     }
 }

--- a/src/oed-authz/Utils/Utils.cs
+++ b/src/oed-authz/Utils/Utils.cs
@@ -12,7 +12,7 @@ public static class SsnUtils
     {
         if (daEvent.Subject == null)
         {
-            throw new ArgumentNullException(nameof(daEvent.Subject));
+            throw new ArgumentNullException(nameof(daEvent), "Missing daEvent.Subject");
         }
 
         if (IsValidSsn(daEvent.Subject))
@@ -27,5 +27,15 @@ public static class SsnUtils
         }
 
         return subject[1];
+    }
+
+    public static string TruncateSsn(string ssn)
+    {
+        if (ssn.Length < 6)
+        {
+            return ssn;
+        }
+     
+        return ssn[..6];
     }
 }

--- a/src/oed-authz/oed-authz.csproj
+++ b/src/oed-authz/oed-authz.csproj
@@ -7,7 +7,7 @@
     <UserSecretsId>cda3e3e5-bca1-4618-9652-784469c6c7da</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.Dd.InternalEvents" Version="2.2.0" />
+    <PackageReference Include="Altinn.Dd.InternalEvents" Version="2.2.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">

--- a/src/oed-authz/oed-authz.csproj
+++ b/src/oed-authz/oed-authz.csproj
@@ -7,7 +7,7 @@
     <UserSecretsId>cda3e3e5-bca1-4618-9652-784469c6c7da</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.Dd.InternalEvents" Version="2.2.1" />
+    <PackageReference Include="Altinn.Dd.InternalEvents" Version="2.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">

--- a/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
+++ b/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
@@ -1669,6 +1669,62 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
             .Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenPersonIsBothHeirAndProxyRecipientInSameEstate_ShouldWipeEstate_WithoutError()
+    {
+        // The protected person is a probate heir AND has received an individual proxy from a
+        // co-heir in the SAME estate (a supported state - see GetEligibleCollectiveProxyRecipients).
+        // Because they are an heir, the whole estate must be wiped, and the operation must not
+        // depend on the order the person's rows happen to come back from the database.
+        var estateSsn = _databaseFixture.NextSsn;
+        var protectedHeirSsn = _databaseFixture.NextSsn;
+        var coHeirSsn = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            // Court role for the protected person (this row drives the full-estate wipe).
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = protectedHeirSsn,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = coHeirSsn,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            // ...and the protected person is also a proxy recipient from the co-heir.
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = protectedHeirSsn,
+                HeirSsn = coHeirSsn,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedHeirSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedHeirSsn })
+        };
+
+        // Act
+        var act = async () => await _sut.HandleEvent(cloudEvent);
+
+        // Assert - must not throw, and the estate must be fully wiped.
+        await act.Should().NotThrowAsync();
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
+    }
+
     public Task InitializeAsync() => Task.CompletedTask;
     public Task DisposeAsync() => Task.CompletedTask;
 }

--- a/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
+++ b/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
@@ -954,6 +954,234 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
             arrangedRoleAssignments.Any(ara => ara.Id == rra.Id));
     }
 
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_ShouldWipeEveryEstateThePersonIsPartOf_AndLeaveOthersUntouched()
+    {
+        // Arrange
+        var protectedPersonSsn = _databaseFixture.NextSsn;
+        var otherHeirSsn = _databaseFixture.NextSsn;
+        var estateA = _databaseFixture.NextSsn;
+        var estateB = _databaseFixture.NextSsn;
+        var unaffectedEstate = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            // Estate A: protected person is a recipient, alongside another heir
+            new RoleAssignment
+            {
+                EstateSsn = estateA,
+                RecipientSsn = protectedPersonSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateA,
+                RecipientSsn = otherHeirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            // Estate B: protected person appears only as the HeirSsn on a proxy assignment
+            new RoleAssignment
+            {
+                EstateSsn = estateB,
+                RecipientSsn = otherHeirSsn,
+                HeirSsn = protectedPersonSsn,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            },
+            // Unaffected estate: protected person not involved at all
+            new RoleAssignment
+            {
+                EstateSsn = unaffectedEstate,
+                RecipientSsn = otherHeirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        // Freg events arrive on the wire as { "nin": "..." }
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedPersonSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedPersonSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - estates A and B are wiped entirely (every heir, not just the protected person)
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateA)
+            .ToList()
+            .Should().BeEmpty();
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateB)
+            .ToList()
+            .Should().BeEmpty();
+
+        // The unrelated estate is left untouched
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == unaffectedEstate)
+            .ToList()
+            .Should().ContainSingle(ra => ra.RecipientSsn == otherHeirSsn);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_ShouldWipeEntireEstate_IncludingAutoManagedCollectiveProxy_CreatedByEstateEvent()
+    {
+        // Arrange - build the estate's role assignments through the real estate-event path,
+        // so the data shape (court roles + the auto-managed collective proxy) matches production.
+        var estateSsn = _databaseFixture.NextSsn;
+        var protectedHeirSsn = _databaseFixture.NextSsn; // probate role -> auto-assigned collective proxy
+        var otherHeirSsn = _databaseFixture.NextSsn;      // formuesfullmakt role
+
+        var estateEventData = new EstateCaseUpdatedEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            ProbateDeadline = DateTimeOffset.UtcNow.AddDays(60),
+            CaseNumber = "abc123",
+            DistrictCourtName = "Oslo tingrett",
+            CaseId = Guid.NewGuid().ToString(),
+            CaseStatus = CaseStatus.Mottatt,
+            HeirRolesV2 = [
+                new PersonHeirRole
+                {
+                    Nin = protectedHeirSsn,
+                    Role = Constants.ProbateRoleCode,
+                    Relation = HeirRoleRelation.Barn,
+                },
+                new PersonHeirRole
+                {
+                    Nin = otherHeirSsn,
+                    Role = Constants.FormuesfullmaktRoleCode,
+                    Relation = HeirRoleRelation.Barn,
+                }
+            ]
+        };
+
+        var estateEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.CaseStatusUpdateValidated,
+            Subject = estateSsn,
+            Data = JsonSerializer.Serialize(estateEventData)
+        };
+
+        await _sut.HandleEvent(estateEvent);
+
+        // Precondition: the estate event produced both court roles plus an auto-managed collective proxy
+        var seededAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        seededAssignments.Should().Contain(ra =>
+            ra.RecipientSsn == protectedHeirSsn && ra.RoleCode == Constants.ProbateRoleCode);
+        seededAssignments.Should().Contain(ra =>
+            ra.RecipientSsn == otherHeirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+        seededAssignments.Should().Contain(ra =>
+            ra.RoleCode == Constants.CollectiveProxyRoleCode);
+
+        // Act: protected-address update for the probate heir
+        var fregEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedHeirSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedHeirSsn })
+        };
+
+        await _sut.HandleEvent(fregEvent);
+
+        // Assert: the entire estate is wiped - court roles, the other heir, and the
+        // auto-managed collective proxy all gone.
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleEvent_EstateEventAfterFregWipe_ShouldReGrantCourtRoles_DocumentingThatWipeIsNotDurable()
+    {
+        // This test documents (it does NOT endorse) current behaviour: a freg protected-address
+        // wipe writes no EventCursor, so a later estate-update event is processed normally and
+        // re-grants the roles the wipe removed. If protected-address removal is meant to be
+        // durable, this test should start failing - which is the signal we want.
+        var estateSsn = _databaseFixture.NextSsn;
+        var heirSsn = _databaseFixture.NextSsn;
+        var firstTimestamp = new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+        var laterTimestamp = firstTimestamp.AddHours(2);
+
+        EstateCaseUpdatedEvent BuildEstateEventData() => new()
+        {
+            Time = DateTimeOffset.UtcNow,
+            ProbateDeadline = DateTimeOffset.UtcNow.AddDays(60),
+            CaseNumber = "abc123",
+            DistrictCourtName = "Oslo tingrett",
+            CaseId = Guid.NewGuid().ToString(),
+            CaseStatus = CaseStatus.Mottatt,
+            HeirRolesV2 = [
+                new PersonHeirRole
+                {
+                    Nin = heirSsn,
+                    Role = Constants.FormuesfullmaktRoleCode,
+                    Relation = HeirRoleRelation.Barn,
+                }
+            ]
+        };
+
+        // Arrange: estate event grants the heir a court role
+        var firstEstateEvent = new CloudEvent
+        {
+            Time = firstTimestamp,
+            Type = EventType.CaseStatusUpdateValidated,
+            Subject = estateSsn,
+            Data = JsonSerializer.Serialize(BuildEstateEventData())
+        };
+
+        await _sut.HandleEvent(firstEstateEvent);
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().ContainSingle(ra =>
+                ra.RecipientSsn == heirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+
+        // Freg protected-address update wipes the estate (and advances no estate EventCursor)
+        var fregEvent = new CloudEvent
+        {
+            Time = firstTimestamp.AddHours(1),
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = heirSsn,
+            Data = JsonSerializer.Serialize(new { nin = heirSsn })
+        };
+
+        await _sut.HandleEvent(fregEvent);
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
+
+        // Act: a later estate sync for the same estate
+        var secondEstateEvent = new CloudEvent
+        {
+            Time = laterTimestamp,
+            Type = EventType.CaseStatusUpdateValidated,
+            Subject = estateSsn,
+            Data = JsonSerializer.Serialize(BuildEstateEventData())
+        };
+
+        await _sut.HandleEvent(secondEstateEvent);
+
+        // Assert: the court role is back - the freg wipe was not durable against a later court sync.
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().ContainSingle(ra =>
+                ra.RecipientSsn == heirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+    }
+
     public Task InitializeAsync() => Task.CompletedTask;
     public Task DisposeAsync() => Task.CompletedTask;
 }

--- a/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
+++ b/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Dd.InternalEvents;
+using Altinn.Dd.InternalEvents;
 using Altinn.Dd.InternalEvents.Estate;
 using FakeItEasy;
 using FluentAssertions;
@@ -1180,6 +1180,493 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
             .ToList()
             .Should().ContainSingle(ra =>
                 ra.RecipientSsn == heirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenProtectedPersonIsOnlyAProxyRecipient_ShouldRemoveOnlyThatProxy_AndLeaveEstateIntact()
+    {
+        // Arrange - the protected person is NOT an heir in this estate. Two heirs hold the
+        // probate role, and the protected person has merely received an individual proxy from
+        // one of them. Per the rule in HandleProtectedAddressUpdate ("Affected nin is a proxy
+        // recipient, only remove the proxy role"), only that single delegation is revoked - the
+        // estate belongs to the heirs and must remain intact.
+        var protectedProxyRecipientSsn = _databaseFixture.NextSsn;
+        var heirWhoDelegated = _databaseFixture.NextSsn;
+        var otherHeir = _databaseFixture.NextSsn;
+        var estateSsn = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = heirWhoDelegated,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = otherHeir,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            // The protected person received an individual proxy from one of the two heirs.
+            // Receiving a proxy from only one of two probate heirs means no collective proxy exists.
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = protectedProxyRecipientSsn,
+                HeirSsn = heirWhoDelegated,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedProxyRecipientSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedProxyRecipientSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - only the proxy pointing at the protected person is gone. Both heirs keep
+        // their probate roles, and no collective proxy is incorrectly added or removed.
+        var remaining = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        remaining.Should().HaveCount(2);
+        remaining.Should().ContainSingle(ra =>
+            ra.RecipientSsn == heirWhoDelegated && ra.RoleCode == Constants.ProbateRoleCode);
+        remaining.Should().ContainSingle(ra =>
+            ra.RecipientSsn == otherHeir && ra.RoleCode == Constants.ProbateRoleCode);
+        remaining.Should().NotContain(ra => ra.RecipientSsn == protectedProxyRecipientSsn);
+        remaining.Should().NotContain(ra => ra.RoleCode == Constants.IndividualProxyRoleCode);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenProtectedPersonIsAnHeirWithCourtRole_ShouldWipeEntireEstate()
+    {
+        // Arrange - the protected person is an heir (holds a court-assigned role). Protecting
+        // them requires wiping the whole estate, including other heirs and any proxy assignments.
+        var protectedHeirSsn = _databaseFixture.NextSsn;
+        var otherHeirSsn = _databaseFixture.NextSsn;
+        var proxyRecipientSsn = _databaseFixture.NextSsn;
+        var estateSsn = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = protectedHeirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = otherHeirSsn,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            // A proxy that does not involve the protected person - it must still be wiped
+            // because the whole estate goes when a heir is protected.
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = proxyRecipientSsn,
+                HeirSsn = otherHeirSsn,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedHeirSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedHeirSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - the entire estate is gone, not just the protected person's own role.
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_ShouldWipeEstatesWhereHeir_RemoveOnlyProxyWhereDelegate_AndLeaveUnrelatedEstatesUntouched()
+    {
+        // A single protected person appears in three estates in three different capacities.
+        // This locks down that the two rules are applied per role assignment, independently,
+        // and that unrelated estates are never touched.
+        var protectedPersonSsn = _databaseFixture.NextSsn;
+
+        // Estate X: protected person is an heir -> the whole estate must be wiped.
+        var estateWhereHeir = _databaseFixture.NextSsn;
+        var coHeirInX = _databaseFixture.NextSsn;
+
+        // Estate Y: protected person is only a proxy recipient -> only that proxy is removed.
+        var estateWhereDelegate = _databaseFixture.NextSsn;
+        var heir1InY = _databaseFixture.NextSsn;
+        var heir2InY = _databaseFixture.NextSsn;
+
+        // Estate Z: protected person not involved -> must be left untouched.
+        var unrelatedEstate = _databaseFixture.NextSsn;
+        var heirInZ = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            // Estate X
+            new RoleAssignment
+            {
+                EstateSsn = estateWhereHeir,
+                RecipientSsn = protectedPersonSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateWhereHeir,
+                RecipientSsn = coHeirInX,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            // Estate Y
+            new RoleAssignment
+            {
+                EstateSsn = estateWhereDelegate,
+                RecipientSsn = heir1InY,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateWhereDelegate,
+                RecipientSsn = heir2InY,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateWhereDelegate,
+                RecipientSsn = protectedPersonSsn,
+                HeirSsn = heir1InY,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            },
+            // Estate Z
+            new RoleAssignment
+            {
+                EstateSsn = unrelatedEstate,
+                RecipientSsn = heirInZ,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedPersonSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedPersonSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - Estate X wiped entirely
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateWhereHeir)
+            .ToList()
+            .Should().BeEmpty();
+
+        // Estate Y: only the proxy to the protected person removed; both heirs' roles intact
+        var estateY = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateWhereDelegate)
+            .ToList();
+
+        estateY.Should().HaveCount(2);
+        estateY.Should().ContainSingle(ra =>
+            ra.RecipientSsn == heir1InY && ra.RoleCode == Constants.ProbateRoleCode);
+        estateY.Should().ContainSingle(ra =>
+            ra.RecipientSsn == heir2InY && ra.RoleCode == Constants.ProbateRoleCode);
+        estateY.Should().NotContain(ra => ra.RecipientSsn == protectedPersonSsn);
+
+        // Estate Z: completely untouched
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == unrelatedEstate)
+            .ToList()
+            .Should().ContainSingle(ra =>
+                ra.RecipientSsn == heirInZ && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenPersonHasNoRoleAssignments_ShouldDoNothing()
+    {
+        // Arrange - a protected-address event for someone with no role assignments at all
+        // must be a safe no-op and must not affect any other estate.
+        var personWithNoRolesSsn = _databaseFixture.NextSsn;
+        var unrelatedEstate = _databaseFixture.NextSsn;
+        var heirSsn = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.Add(
+            new RoleAssignment
+            {
+                EstateSsn = unrelatedEstate,
+                RecipientSsn = heirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = personWithNoRolesSsn,
+            Data = JsonSerializer.Serialize(new { nin = personWithNoRolesSsn })
+        };
+
+        // Act
+        var act = async () => await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == unrelatedEstate)
+            .ToList()
+            .Should().ContainSingle(ra => ra.RecipientSsn == heirSsn);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WithNullData_ShouldThrowArgumentNullException()
+    {
+        // Arrange - a freg event with no data payload should be rejected before any DB work.
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = _databaseFixture.NextSsn,
+            Data = null!
+        };
+
+        // Act
+        var act = async () => await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WithJsonNullData_ShouldReturnWithoutRemovingAnything()
+    {
+        // Arrange - a payload that deserializes to null (JSON literal null) must be treated as
+        // a safe no-op: the handler returns early and touches no role assignments.
+        var estateSsn = _databaseFixture.NextSsn;
+        var heirSsn = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.Add(
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = heirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = heirSsn,
+            Data = "null" // deserializes to null -> handler returns early
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().ContainSingle(ra => ra.RecipientSsn == heirSsn);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenProtectedPersonIsANonHeirHoldingCollectiveProxy_ShouldRemoveOnlyTheirProxies_AndLeaveEstateIntact()
+    {
+        // Arrange - the protected person is NOT an heir. They received an individual proxy from
+        // BOTH probate heirs and therefore also hold the auto-managed collective proxy. Only that
+        // person's proxy access (individual + collective) should be revoked - the heirs keep their
+        // own court roles and the estate must stay intact.
+        var estateSsn = _databaseFixture.NextSsn;
+        var heir1 = _databaseFixture.NextSsn;
+        var heir2 = _databaseFixture.NextSsn;
+        var nonHeirDelegate = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = heir1,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = heir2,
+                RoleCode = Constants.ProbateRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = nonHeirDelegate,
+                HeirSsn = heir1,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = nonHeirDelegate,
+                HeirSsn = heir2,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            },
+            // Auto-managed collective proxy the delegate holds because they received a proxy from
+            // every probate heir. Note it has no HeirSsn - the row that used to trigger a full wipe.
+            new RoleAssignment
+            {
+                EstateSsn = estateSsn,
+                RecipientSsn = nonHeirDelegate,
+                RoleCode = Constants.CollectiveProxyRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = nonHeirDelegate,
+            Data = JsonSerializer.Serialize(new { nin = nonHeirDelegate })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - both heirs keep their probate roles; every trace of the delegate's proxy
+        // access (individual and collective) is gone. The estate is NOT wiped.
+        var remaining = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        remaining.Should().HaveCount(2);
+        remaining.Should().ContainSingle(ra =>
+            ra.RecipientSsn == heir1 && ra.RoleCode == Constants.ProbateRoleCode);
+        remaining.Should().ContainSingle(ra =>
+            ra.RecipientSsn == heir2 && ra.RoleCode == Constants.ProbateRoleCode);
+        remaining.Should().NotContain(ra => ra.RecipientSsn == nonHeirDelegate);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenPersonIsAProxyRecipientInMultipleEstates_ShouldRemoveOnlyTheirProxiesInEach_RegardlessOfHeirCount()
+    {
+        // The protected person is a NON-heir delegate in two different estates at once:
+        //  - Estate S has a single probate heir.
+        //  - Estate M has two probate heirs.
+        // In both, the delegate received a proxy from every heir and therefore also holds the
+        // auto-managed collective proxy. The freg event must revoke only the delegate's proxy
+        // access in each estate, leaving each estate's own heirs untouched.
+        var delegateSsn = _databaseFixture.NextSsn;
+
+        // Estate S - single heir
+        var estateS = _databaseFixture.NextSsn;
+        var soleHeir = _databaseFixture.NextSsn;
+
+        // Estate M - multiple heirs
+        var estateM = _databaseFixture.NextSsn;
+        var heirM1 = _databaseFixture.NextSsn;
+        var heirM2 = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            // Estate S: the sole probate heir (who, being the only heir, also holds a collective
+            // proxy), plus the delegate's individual + collective proxy.
+            new RoleAssignment { EstateSsn = estateS, RecipientSsn = soleHeir, RoleCode = Constants.ProbateRoleCode },
+            new RoleAssignment { EstateSsn = estateS, RecipientSsn = soleHeir, RoleCode = Constants.CollectiveProxyRoleCode },
+            new RoleAssignment { EstateSsn = estateS, RecipientSsn = delegateSsn, HeirSsn = soleHeir, RoleCode = Constants.IndividualProxyRoleCode },
+            new RoleAssignment { EstateSsn = estateS, RecipientSsn = delegateSsn, RoleCode = Constants.CollectiveProxyRoleCode },
+            // Estate M: two probate heirs and the delegate's two individual proxies + collective proxy.
+            new RoleAssignment { EstateSsn = estateM, RecipientSsn = heirM1, RoleCode = Constants.ProbateRoleCode },
+            new RoleAssignment { EstateSsn = estateM, RecipientSsn = heirM2, RoleCode = Constants.ProbateRoleCode },
+            new RoleAssignment { EstateSsn = estateM, RecipientSsn = delegateSsn, HeirSsn = heirM1, RoleCode = Constants.IndividualProxyRoleCode },
+            new RoleAssignment { EstateSsn = estateM, RecipientSsn = delegateSsn, HeirSsn = heirM2, RoleCode = Constants.IndividualProxyRoleCode },
+            new RoleAssignment { EstateSsn = estateM, RecipientSsn = delegateSsn, RoleCode = Constants.CollectiveProxyRoleCode });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = delegateSsn,
+            Data = JsonSerializer.Serialize(new { nin = delegateSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - Estate S (single heir): only the sole heir's rows remain, the delegate is gone.
+        var estateSRemaining = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateS)
+            .ToList();
+
+        estateSRemaining.Should().OnlyContain(ra => ra.RecipientSsn == soleHeir);
+        estateSRemaining.Should().Contain(ra => ra.RoleCode == Constants.ProbateRoleCode);
+        estateSRemaining.Should().NotContain(ra => ra.RecipientSsn == delegateSsn);
+
+        // Estate M (multiple heirs): both heirs keep their probate roles, the delegate is gone.
+        var estateMRemaining = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateM)
+            .ToList();
+
+        estateMRemaining.Should().HaveCount(2);
+        estateMRemaining.Should().ContainSingle(ra => ra.RecipientSsn == heirM1 && ra.RoleCode == Constants.ProbateRoleCode);
+        estateMRemaining.Should().ContainSingle(ra => ra.RecipientSsn == heirM2 && ra.RoleCode == Constants.ProbateRoleCode);
+        estateMRemaining.Should().NotContain(ra => ra.RecipientSsn == delegateSsn);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_WhenProtectedPersonIsTheSoleHeir_ShouldWipeEntireEstate()
+    {
+        // A single-heir estate where the protected person IS that heir. The whole estate must be
+        // wiped, including the collective proxy the sole heir automatically holds.
+        var soleHeirSsn = _databaseFixture.NextSsn;
+        var estateSsn = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            new RoleAssignment { EstateSsn = estateSsn, RecipientSsn = soleHeirSsn, RoleCode = Constants.ProbateRoleCode },
+            new RoleAssignment { EstateSsn = estateSsn, RecipientSsn = soleHeirSsn, RoleCode = Constants.CollectiveProxyRoleCode });
+
+        await _dbContext.SaveChangesAsync();
+
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = soleHeirSsn,
+            Data = JsonSerializer.Serialize(new { nin = soleHeirSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
     }
 
     public Task InitializeAsync() => Task.CompletedTask;

--- a/test/oed-authz.UnitTests/Utils/SsnUtilsTests.cs
+++ b/test/oed-authz.UnitTests/Utils/SsnUtilsTests.cs
@@ -1,0 +1,128 @@
+using FluentAssertions;
+using oed_authz.Models;
+using oed_authz.Utils;
+
+namespace oed_authz.UnitTests.Utils;
+
+public class SsnUtilsTests
+{
+    [Theory]
+    [InlineData("12345678901")] // arbitrary 11 digits
+    [InlineData("00000000000")] // all zeros
+    [InlineData("99999999999")] // all nines
+    public void IsValidSsn_WhenExactlyElevenDigits_ReturnsTrue(string ssn)
+    {
+        SsnUtils.IsValidSsn(ssn).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]              // empty
+    [InlineData("1")]             // single digit
+    [InlineData("1234567890")]    // 10 digits
+    [InlineData("123456789012")]  // 12 digits
+    public void IsValidSsn_WhenLengthIsNotEleven_ReturnsFalse(string ssn)
+    {
+        SsnUtils.IsValidSsn(ssn).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("1234567890a")]   // trailing letter
+    [InlineData("a1234567890")]   // leading letter
+    [InlineData("12345 678901")]  // embedded space
+    [InlineData(" 1234567890")]   // leading space
+    [InlineData("1234567890 ")]   // trailing space
+    [InlineData("12345-678901")]  // punctuation (also makes it 12 chars, still false)
+    [InlineData("1234567890+")]   // sign character
+    public void IsValidSsn_WhenContainsNonDigitCharacter_ReturnsFalse(string ssn)
+    {
+        SsnUtils.IsValidSsn(ssn).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("١٢٣٤٥٦٧٨٩٠١")] // Arabic-Indic digits (11 chars, outside '0'..'9')
+    [InlineData("１２３４５６７８９０１")] // full-width digits (11 chars, outside '0'..'9')
+    public void IsValidSsn_WhenContainsNonAsciiDigits_ReturnsFalse(string ssn)
+    {
+        SsnUtils.IsValidSsn(ssn).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidSsn_WhenNull_ReturnsFalse()
+    {
+        SsnUtils.IsValidSsn(null!).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("12345678901")]              // bare SSN, returned directly
+    [InlineData("/person/12345678901")]      // '/person/' prefix with leading slash
+    [InlineData("person/12345678901")]       // '/person/' prefix without leading slash
+    [InlineData("/person/12345678901/")]     // trailing slash removed
+    [InlineData("person / 12345678901")]     // surrounding whitespace trimmed
+    public void GetEstateSsnFromCloudEvent_WhenSubjectResolvesToValidSsn_ReturnsSsn(string subject)
+    {
+        var daEvent = new CloudEvent { Subject = subject };
+
+        SsnUtils.GetEstateSsnFromCloudEvent(daEvent).Should().Be("12345678901");
+    }
+
+    [Theory]
+    [InlineData("not-an-ssn")]                 // single non-SSN segment
+    [InlineData("1234567890")]                 // 10 digits, not a valid SSN
+    [InlineData("/party/12345678901")]         // wrong prefix
+    [InlineData("/person/1234")]               // valid prefix but invalid SSN
+    [InlineData("/person/12345678901/extra")]  // too many segments
+    [InlineData("/person")]                    // missing SSN segment
+    [InlineData("   ")]                         // whitespace only (not caught by null/empty guard)
+    public void GetEstateSsnFromCloudEvent_WhenSubjectIsNotAValidSsnReference_ThrowsArgumentException(string subject)
+    {
+        var daEvent = new CloudEvent { Subject = subject };
+        var act = () => SsnUtils.GetEstateSsnFromCloudEvent(daEvent);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GetEstateSsnFromCloudEvent_WhenSubjectIsNull_ThrowsArgumentNullException()
+    {
+        var daEvent = new CloudEvent { Subject = null };
+        var act = () => SsnUtils.GetEstateSsnFromCloudEvent(daEvent);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetEstateSsnFromCloudEvent_WhenSubjectIsEmpty_ThrowsArgumentException()
+    {
+        var daEvent = new CloudEvent { Subject = "" };
+        var act = () => SsnUtils.GetEstateSsnFromCloudEvent(daEvent);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("12345678901", "123456")] // full 11-digit SSN truncated to first 6 (birth date)
+    [InlineData("123456", "123456")]      // exactly 6 chars, unchanged
+    [InlineData("1234567", "123456")]     // 7 chars, truncated
+    public void TruncateSsn_WhenLengthIsSixOrMore_ReturnsFirstSixCharacters(string ssn, string expected)
+    {
+        SsnUtils.TruncateSsn(ssn).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]      // empty
+    [InlineData("1")]     // single char
+    [InlineData("12345")] // 5 chars, one short of the cutoff
+    public void TruncateSsn_WhenLengthIsLessThanSix_ReturnsInputUnchanged(string ssn)
+    {
+        SsnUtils.TruncateSsn(ssn).Should().Be(ssn);
+    }
+
+    [Fact]
+    public void TruncateSsn_WhenNull_ThrowsNullReferenceException()
+    {
+        // Documents current behavior: TruncateSsn has no null guard (unlike IsValidSsn).
+        var act = () => SsnUtils.TruncateSsn(null!);
+
+        act.Should().Throw<NullReferenceException>();
+    }
+}


### PR DESCRIPTION
- Add GetAllRoleAssignmentsForPerson to find a person's estates by recipient or heir SSN
- Wrap the multi-estate removal in a transaction so it is atomic
- Extract ThrowIfEmptyData; log only event id/type instead of the full serialized event (which contains SSNs)
- Bump Altinn.Dd.InternalEvents to 2.2.1 (fixes FregProtectedAddressUpdateEvent.Nin not deserializing under default JsonSerializer options)
- Add SsnUtils.TruncateSsn for safe logging
- Add integration tests covering the wipe, auto-managed collective-proxy clearing, and the estate-event/freg-event interaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated handling for protected address update events to refresh authorization/access across affected estates and proxy roles.
  * Added the ability to retrieve all role assignments for a person, plus an SSN truncation helper.
* **Bug Fixes**
  * Improved safety for missing/invalid identifiers and event data, including stricter SSN validation and subject parsing.
  * Avoids unnecessary database calls by returning empty results when inputs are blank.
* **Tests**
  * Added integration and unit test coverage for protected address updates and SSN utilities.
* **Chores**
  * Updated the internal events package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->