### PR TITLE
Handle freg protected-address events by wiping affected estates

### DIFF
--- a/src/oed-authz/Interfaces/IRoleAssignmentsRepository.cs
+++ b/src/oed-authz/Interfaces/IRoleAssignmentsRepository.cs
@@ -6,6 +6,7 @@ public interface IRoleAssignmentsRepository
 {
     public Task<List<RoleAssignment>> GetRoleAssignmentsForEstate(string estateSsn);
     public Task<List<RoleAssignment>> GetRoleAssignmentsForPerson(string estateSsn, string recipientSsn);
+    public Task<List<RoleAssignment>> GetAllRoleAssignmentsForPerson(string ssn);
     public Task AddRoleAssignment(RoleAssignment roleAssignment);
     public Task RemoveRoleAssignment(RoleAssignment roleAssignment);
 }

--- a/src/oed-authz/Repositories/RoleAssignmentsRepository.cs
+++ b/src/oed-authz/Repositories/RoleAssignmentsRepository.cs
@@ -38,6 +38,14 @@ namespace oed_authz.Repositories
                 .ToListAsync();
         }
 
+        public Task<List<RoleAssignment>> GetAllRoleAssignmentsForPerson(string ssn)
+        {
+            return _dbContext.RoleAssignments
+                .Where(ra => ra.HeirSsn == ssn || ra.RecipientSsn == ssn)
+                .AsNoTracking()
+                .ToListAsync();
+        }
+
         public Task RemoveRoleAssignment(RoleAssignment roleAssignment)
         {
             return _dbContext.RoleAssignments

--- a/src/oed-authz/Services/EventHandlerService.cs
+++ b/src/oed-authz/Services/EventHandlerService.cs
@@ -33,10 +33,29 @@ public class AltinnEventHandlerService(
 
     private async Task HandleProtectedAddressUpdate(CloudEvent fregEvent)
     {
-        logger.LogInformation("Placeholder for handling protected address update event {Id} of type {EventType} for subject {Subject}",
-            fregEvent.Id, 
-            fregEvent.Type, 
-            fregEvent.Subject[..Math.Min(fregEvent.Subject.Length, 6)]);
+        ThrowIfEmptyData(fregEvent);
+
+        logger.LogInformation("Handling protected address update event {Id} from freg", fregEvent.Id);
+
+        var eventData = JsonSerializer.Deserialize<FregProtectedAddressUpdateEvent>(fregEvent.Data.ToString()!);
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+        var roleAssignmentsForPerson = await oedRoleRepositoryService.GetAllRoleAssignmentsForPerson(eventData!.Nin);
+     
+        var estatesPersonIsPartOf = roleAssignmentsForPerson
+            .Select(x => x.EstateSsn)
+            .Distinct();
+        
+        foreach (var estateSsn in estatesPersonIsPartOf)
+        {
+            logger.LogInformation("Removing all role assignments for estate {EstateSsn} due to protected address update for person with Nin {Nin}",
+                estateSsn, SsnUtils.TruncateSsn(eventData.Nin));
+
+            await RemoveAllRoleAssignmentsForEstate(estateSsn, fregEvent.Id);
+        }
+
+        await transaction.CommitAsync();
     }
 
     private async Task HandleEstateInstanceCreatedOrUpdated(CloudEvent daEvent)
@@ -57,11 +76,7 @@ public class AltinnEventHandlerService(
             return;
         }
 
-        if (daEvent.Data == null)
-        {
-            logger.LogError("Empty data in event: {CloudEvent}", JsonSerializer.Serialize(daEvent));
-            throw new ArgumentNullException(nameof(daEvent.Data));
-        }
+        ThrowIfEmptyData(daEvent);
 
         var eventData = JsonSerializer.Deserialize<EstateCaseUpdatedEvent>(daEvent.Data.ToString()!)!;
         logger.LogInformation("Handling event {Id} for DA caseId: {DaCaseId}", daEvent.Id, eventData.CaseId);
@@ -172,6 +187,15 @@ public class AltinnEventHandlerService(
         foreach (var roleAssignment in assignmentsToRemove)
         {
             await oedRoleRepositoryService.RemoveRoleAssignment(roleAssignment);
+        }
+    }
+
+    private void ThrowIfEmptyData(CloudEvent cloudEvent)
+    {
+        if (cloudEvent.Data == null)
+        {
+            logger.LogError("Empty data in event {Id} of type {EventType}", cloudEvent.Id, cloudEvent.Type);
+            throw new ArgumentNullException(nameof(cloudEvent), "CloudEvent data is null");
         }
     }
 

--- a/src/oed-authz/Utils/Utils.cs
+++ b/src/oed-authz/Utils/Utils.cs
@@ -12,7 +12,7 @@ public static class SsnUtils
     {
         if (daEvent.Subject == null)
         {
-            throw new ArgumentNullException(nameof(daEvent.Subject));
+            throw new ArgumentNullException(nameof(daEvent), "Missing daEvent.Subject");
         }
 
         if (IsValidSsn(daEvent.Subject))
@@ -27,5 +27,15 @@ public static class SsnUtils
         }
 
         return subject[1];
+    }
+
+    public static string TruncateSsn(string ssn)
+    {
+        if (ssn.Length < 6)
+        {
+            return ssn;
+        }
+     
+        return ssn[..6];
     }
 }

--- a/src/oed-authz/oed-authz.csproj
+++ b/src/oed-authz/oed-authz.csproj
@@ -7,7 +7,7 @@
     <UserSecretsId>cda3e3e5-bca1-4618-9652-784469c6c7da</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.Dd.InternalEvents" Version="2.2.0" />
+    <PackageReference Include="Altinn.Dd.InternalEvents" Version="2.2.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">

--- a/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
+++ b/test/oed-authz.IntegrationTests/Services/EventHandlerServiceTests.cs
@@ -954,6 +954,234 @@ public class EventHandlerServiceTests : IClassFixture<DatabaseFixture>, IAsyncLi
             arrangedRoleAssignments.Any(ara => ara.Id == rra.Id));
     }
 
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_ShouldWipeEveryEstateThePersonIsPartOf_AndLeaveOthersUntouched()
+    {
+        // Arrange
+        var protectedPersonSsn = _databaseFixture.NextSsn;
+        var otherHeirSsn = _databaseFixture.NextSsn;
+        var estateA = _databaseFixture.NextSsn;
+        var estateB = _databaseFixture.NextSsn;
+        var unaffectedEstate = _databaseFixture.NextSsn;
+
+        _dbContext.RoleAssignments.AddRange(
+            // Estate A: protected person is a recipient, alongside another heir
+            new RoleAssignment
+            {
+                EstateSsn = estateA,
+                RecipientSsn = protectedPersonSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            new RoleAssignment
+            {
+                EstateSsn = estateA,
+                RecipientSsn = otherHeirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            },
+            // Estate B: protected person appears only as the HeirSsn on a proxy assignment
+            new RoleAssignment
+            {
+                EstateSsn = estateB,
+                RecipientSsn = otherHeirSsn,
+                HeirSsn = protectedPersonSsn,
+                RoleCode = Constants.IndividualProxyRoleCode,
+            },
+            // Unaffected estate: protected person not involved at all
+            new RoleAssignment
+            {
+                EstateSsn = unaffectedEstate,
+                RecipientSsn = otherHeirSsn,
+                RoleCode = Constants.FormuesfullmaktRoleCode,
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        // Freg events arrive on the wire as { "nin": "..." }
+        var cloudEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedPersonSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedPersonSsn })
+        };
+
+        // Act
+        await _sut.HandleEvent(cloudEvent);
+
+        // Assert - estates A and B are wiped entirely (every heir, not just the protected person)
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateA)
+            .ToList()
+            .Should().BeEmpty();
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateB)
+            .ToList()
+            .Should().BeEmpty();
+
+        // The unrelated estate is left untouched
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == unaffectedEstate)
+            .ToList()
+            .Should().ContainSingle(ra => ra.RecipientSsn == otherHeirSsn);
+    }
+
+    [Fact]
+    public async Task HandleEvent_FregProtectedAddressUpdate_ShouldWipeEntireEstate_IncludingAutoManagedCollectiveProxy_CreatedByEstateEvent()
+    {
+        // Arrange - build the estate's role assignments through the real estate-event path,
+        // so the data shape (court roles + the auto-managed collective proxy) matches production.
+        var estateSsn = _databaseFixture.NextSsn;
+        var protectedHeirSsn = _databaseFixture.NextSsn; // probate role -> auto-assigned collective proxy
+        var otherHeirSsn = _databaseFixture.NextSsn;      // formuesfullmakt role
+
+        var estateEventData = new EstateCaseUpdatedEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            ProbateDeadline = DateTimeOffset.UtcNow.AddDays(60),
+            CaseNumber = "abc123",
+            DistrictCourtName = "Oslo tingrett",
+            CaseId = Guid.NewGuid().ToString(),
+            CaseStatus = CaseStatus.Mottatt,
+            HeirRolesV2 = [
+                new PersonHeirRole
+                {
+                    Nin = protectedHeirSsn,
+                    Role = Constants.ProbateRoleCode,
+                    Relation = HeirRoleRelation.Barn,
+                },
+                new PersonHeirRole
+                {
+                    Nin = otherHeirSsn,
+                    Role = Constants.FormuesfullmaktRoleCode,
+                    Relation = HeirRoleRelation.Barn,
+                }
+            ]
+        };
+
+        var estateEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.CaseStatusUpdateValidated,
+            Subject = estateSsn,
+            Data = JsonSerializer.Serialize(estateEventData)
+        };
+
+        await _sut.HandleEvent(estateEvent);
+
+        // Precondition: the estate event produced both court roles plus an auto-managed collective proxy
+        var seededAssignments = _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList();
+
+        seededAssignments.Should().Contain(ra =>
+            ra.RecipientSsn == protectedHeirSsn && ra.RoleCode == Constants.ProbateRoleCode);
+        seededAssignments.Should().Contain(ra =>
+            ra.RecipientSsn == otherHeirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+        seededAssignments.Should().Contain(ra =>
+            ra.RoleCode == Constants.CollectiveProxyRoleCode);
+
+        // Act: protected-address update for the probate heir
+        var fregEvent = new CloudEvent
+        {
+            Time = DateTimeOffset.UtcNow,
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = protectedHeirSsn,
+            Data = JsonSerializer.Serialize(new { nin = protectedHeirSsn })
+        };
+
+        await _sut.HandleEvent(fregEvent);
+
+        // Assert: the entire estate is wiped - court roles, the other heir, and the
+        // auto-managed collective proxy all gone.
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleEvent_EstateEventAfterFregWipe_ShouldReGrantCourtRoles_DocumentingThatWipeIsNotDurable()
+    {
+        // This test documents (it does NOT endorse) current behaviour: a freg protected-address
+        // wipe writes no EventCursor, so a later estate-update event is processed normally and
+        // re-grants the roles the wipe removed. If protected-address removal is meant to be
+        // durable, this test should start failing - which is the signal we want.
+        var estateSsn = _databaseFixture.NextSsn;
+        var heirSsn = _databaseFixture.NextSsn;
+        var firstTimestamp = new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+        var laterTimestamp = firstTimestamp.AddHours(2);
+
+        EstateCaseUpdatedEvent BuildEstateEventData() => new()
+        {
+            Time = DateTimeOffset.UtcNow,
+            ProbateDeadline = DateTimeOffset.UtcNow.AddDays(60),
+            CaseNumber = "abc123",
+            DistrictCourtName = "Oslo tingrett",
+            CaseId = Guid.NewGuid().ToString(),
+            CaseStatus = CaseStatus.Mottatt,
+            HeirRolesV2 = [
+                new PersonHeirRole
+                {
+                    Nin = heirSsn,
+                    Role = Constants.FormuesfullmaktRoleCode,
+                    Relation = HeirRoleRelation.Barn,
+                }
+            ]
+        };
+
+        // Arrange: estate event grants the heir a court role
+        var firstEstateEvent = new CloudEvent
+        {
+            Time = firstTimestamp,
+            Type = EventType.CaseStatusUpdateValidated,
+            Subject = estateSsn,
+            Data = JsonSerializer.Serialize(BuildEstateEventData())
+        };
+
+        await _sut.HandleEvent(firstEstateEvent);
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().ContainSingle(ra =>
+                ra.RecipientSsn == heirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+
+        // Freg protected-address update wipes the estate (and advances no estate EventCursor)
+        var fregEvent = new CloudEvent
+        {
+            Time = firstTimestamp.AddHours(1),
+            Type = EventType.FregProtectedAddressUpdate,
+            Subject = heirSsn,
+            Data = JsonSerializer.Serialize(new { nin = heirSsn })
+        };
+
+        await _sut.HandleEvent(fregEvent);
+
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().BeEmpty();
+
+        // Act: a later estate sync for the same estate
+        var secondEstateEvent = new CloudEvent
+        {
+            Time = laterTimestamp,
+            Type = EventType.CaseStatusUpdateValidated,
+            Subject = estateSsn,
+            Data = JsonSerializer.Serialize(BuildEstateEventData())
+        };
+
+        await _sut.HandleEvent(secondEstateEvent);
+
+        // Assert: the court role is back - the freg wipe was not durable against a later court sync.
+        _dbContext.RoleAssignments
+            .Where(ra => ra.EstateSsn == estateSsn)
+            .ToList()
+            .Should().ContainSingle(ra =>
+                ra.RecipientSsn == heirSsn && ra.RoleCode == Constants.FormuesfullmaktRoleCode);
+    }
+
     public Task InitializeAsync() => Task.CompletedTask;
     public Task DisposeAsync() => Task.CompletedTask;
 }


### PR DESCRIPTION
When a person receives a protected address from Folkeregisteret, remove all role assignments for every estate that person is part of.

- Add GetAllRoleAssignmentsForPerson to find a person's estates by recipient or heir SSN
- Wrap the multi-estate removal in a transaction so it is atomic
- Extract ThrowIfEmptyData; log only event id/type instead of the full serialized event (which contains SSNs)
- Bump Altinn.Dd.InternalEvents to 2.2.1 (fixes FregProtectedAddressUpdateEvent.Nin not deserializing under default JsonSerializer options)
- Add SsnUtils.TruncateSsn for safe logging
- Add integration tests covering the wipe, auto-managed collective-proxy clearing, and the estate-event/freg-event interaction

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role access can now be refreshed for a person based on a protected-address update, clearing related estate permissions when needed.

* **Bug Fixes**
  * Improved handling of missing event data with clearer validation and error messages.
  * Added a utility for safely shortening ID values used in lookups and processing.

* **Chores**
  * Updated a platform dependency to the latest patch version.

* **Tests**
  * Added integration coverage for protected-address updates and estate role cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->